### PR TITLE
Add Jira issue validation steps.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,3 +17,13 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
           node script.js
+      - name: Log in to Jira
+        uses: atlassian/gajira-login@master
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      - name: Validate Jira Issue in branch name
+        uses: atlassian/gajira-find-issue-key@master
+        with:
+          from: branch


### PR DESCRIPTION
atlassian/gajira actions are Atlassian's official github actions.
Creds are taken from secrets. If the "Validate Jira Issue in branch name" step fails, the action will fail.